### PR TITLE
Metrics set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ a low level, while retaining the statistical information.
 - **Timer**: a combination of meter and histogram.
 - **Gauge**: a function that provides value when queried.
 
+### MetricsRegistry
+
+An entrypoint and holder of all metrics.
+
+### MetricsSet
+
+A trait to be implemented so that dynamic metrics can be added into registry. Metrics from the set
+are pulled into registry everytime when reporters and exporters pulling values from the registry.
+
 ### Reporter
 
 A component to report metric data periodically. Typically used for data sinks which has a push-model.

--- a/metriki-core/examples/top.rs
+++ b/metriki-core/examples/top.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::Arc;
+
+use metriki_core::metrics::{Counter, Metric};
+use metriki_core::{MetricsRegistry, MetricsSet};
+
+#[derive(Debug)]
+struct Top {
+    counters: Vec<Arc<Counter>>,
+    n: usize,
+}
+
+impl MetricsSet for Top {
+    fn get_all(&self) -> HashMap<String, Metric> {
+        let mut working_copy = self.counters.clone();
+        working_copy.sort_by_key(|c| -c.value());
+
+        working_copy
+            .iter()
+            .take(self.n)
+            .cloned()
+            .enumerate()
+            .map(|(idx, c)| (format!("counter.top.{}", idx), c.into()))
+            .collect::<HashMap<String, Metric>>()
+    }
+}
+
+impl Top {
+    fn new(total: usize, top: usize) -> Top {
+        Top {
+            counters: (0..total).map(|_| Metric::counter()).collect(),
+            n: top,
+        }
+    }
+
+    fn inc_n(&self, idx: usize, n: i64) {
+        if let Some(c) = self.counters.get(idx) {
+            c.inc(n);
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mr = MetricsRegistry::new();
+    let size = 10;
+    let top = Arc::new(Top::new(size, 3));
+    mr.register_metrics_set("top", top.clone());
+
+    // random inc
+    for i in 0..size {
+        top.inc_n(i, (rand::random::<f64>() * 100f64) as i64);
+    }
+
+    let snapshots = mr.snapshots();
+
+    println!("{:?}", snapshots);
+    Ok(())
+}

--- a/metriki-core/src/lib.rs
+++ b/metriki-core/src/lib.rs
@@ -62,6 +62,7 @@
 
 mod filter;
 pub mod metrics;
+mod mset;
 mod registry;
 mod utils;
 

--- a/metriki-core/src/lib.rs
+++ b/metriki-core/src/lib.rs
@@ -67,4 +67,5 @@ mod registry;
 mod utils;
 
 pub use filter::MetricsFilter;
+pub use mset::MetricsSet;
 pub use registry::MetricsRegistry;

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -20,58 +20,58 @@ pub enum Metric {
 
 impl Metric {
     /// Create default meter
-    pub fn meter() -> Meter {
-        Meter::new()
+    pub fn meter() -> Arc<Meter> {
+        Meter::new().into()
     }
 
     /// Create default timer
-    pub fn timer() -> Timer {
-        Timer::new()
+    pub fn timer() -> Arc<Timer> {
+        Timer::new().into()
     }
 
     /// Create gauge with given function
-    pub fn gauge(f: GaugeFn) -> Gauge {
-        Gauge::new(f)
+    pub fn gauge(f: GaugeFn) -> Arc<Gauge> {
+        Gauge::new(f).into()
     }
 
     /// Create default histogram
-    pub fn histogram() -> Histogram {
-        Histogram::new()
+    pub fn histogram() -> Arc<Histogram> {
+        Histogram::new().into()
     }
 
     /// Create default counter
-    pub fn counter() -> Counter {
-        Counter::new()
+    pub fn counter() -> Arc<Counter> {
+        Counter::new().into()
     }
 }
 
-impl From<Meter> for Metric {
-    fn from(f: Meter) -> Metric {
-        Metric::Meter(Arc::new(f))
+impl From<Arc<Meter>> for Metric {
+    fn from(f: Arc<Meter>) -> Metric {
+        Metric::Meter(f)
     }
 }
 
-impl From<Timer> for Metric {
-    fn from(f: Timer) -> Metric {
-        Metric::Timer(Arc::new(f))
+impl From<Arc<Timer>> for Metric {
+    fn from(f: Arc<Timer>) -> Metric {
+        Metric::Timer(f)
     }
 }
 
-impl From<Counter> for Metric {
-    fn from(f: Counter) -> Metric {
-        Metric::Counter(Arc::new(f))
+impl From<Arc<Counter>> for Metric {
+    fn from(f: Arc<Counter>) -> Metric {
+        Metric::Counter(f)
     }
 }
 
-impl From<Gauge> for Metric {
-    fn from(f: Gauge) -> Metric {
-        Metric::Gauge(Arc::new(f))
+impl From<Arc<Gauge>> for Metric {
+    fn from(f: Arc<Gauge>) -> Metric {
+        Metric::Gauge(f)
     }
 }
 
-impl From<Histogram> for Metric {
-    fn from(f: Histogram) -> Metric {
-        Metric::Histogram(Arc::new(f))
+impl From<Arc<Histogram>> for Metric {
+    fn from(f: Arc<Histogram>) -> Metric {
+        Metric::Histogram(f)
     }
 }
 

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -43,6 +43,46 @@ impl Metric {
     pub fn counter() -> Arc<Counter> {
         Counter::new().into()
     }
+
+    /// Convert the Metric to `Meter`
+    pub fn as_meter(&self) -> Option<Arc<Meter>> {
+        match self {
+            Metric::Meter(m) => Some(m.clone()),
+            _ => None,
+        }
+    }
+
+    /// Convert the Metric to `Timer`
+    pub fn as_timer(&self) -> Option<Arc<Timer>> {
+        match self {
+            Metric::Timer(m) => Some(m.clone()),
+            _ => None,
+        }
+    }
+
+    /// Convert the Metric to `Gauge`
+    pub fn as_gauge(&self) -> Option<Arc<Gauge>> {
+        match self {
+            Metric::Gauge(m) => Some(m.clone()),
+            _ => None,
+        }
+    }
+
+    /// Convert the Metric to `Histogram`
+    pub fn as_histogram(&self) -> Option<Arc<Histogram>> {
+        match self {
+            Metric::Histogram(m) => Some(m.clone()),
+            _ => None,
+        }
+    }
+
+    /// Convert the Metric to `Counter`
+    pub fn as_counter(&self) -> Option<Arc<Counter>> {
+        match self {
+            Metric::Counter(m) => Some(m.clone()),
+            _ => None,
+        }
+    }
 }
 
 impl From<Arc<Meter>> for Metric {

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
 #[cfg(feature = "ser")]
-use serde::ser::SerializeSeq;
-#[cfg(feature = "ser")]
 use serde::{Serialize, Serializer};
 
 mod counter;

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -9,7 +9,6 @@ mod counter;
 mod gauge;
 mod histogram;
 mod meter;
-mod mset;
 mod timer;
 
 #[derive(Clone, Debug)]
@@ -19,7 +18,6 @@ pub enum Metric {
     Gauge(Arc<Gauge>),
     Histogram(Arc<Histogram>),
     Counter(Arc<Counter>),
-    MetricsSet(Arc<Box<dyn MetricsSet>>),
 }
 
 #[cfg(feature = "ser")]
@@ -34,16 +32,6 @@ impl Serialize for Metric {
             Metric::Gauge(inner) => inner.serialize(serializer),
             Metric::Histogram(inner) => inner.serialize(serializer),
             Metric::Counter(inner) => inner.serialize(serializer),
-            Metric::MetricsSet(inner) => {
-                let metrics = inner.get_all();
-
-                let mut array = serializer.serialize_seq(Some(metrics.len()))?;
-                for m in metrics {
-                    array.serialize_element(&m)?;
-                }
-
-                array.end()
-            }
         }
     }
 }
@@ -52,5 +40,4 @@ pub use counter::Counter;
 pub use gauge::{Gauge, GaugeFn};
 pub use histogram::{Histogram, HistogramSnapshot};
 pub use meter::Meter;
-pub use mset::MetricsSet;
 pub use timer::Timer;

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -47,6 +47,36 @@ impl Metric {
     }
 }
 
+impl From<Meter> for Metric {
+    fn from(f: Meter) -> Metric {
+        Metric::Meter(Arc::new(f))
+    }
+}
+
+impl From<Timer> for Metric {
+    fn from(f: Timer) -> Metric {
+        Metric::Timer(Arc::new(f))
+    }
+}
+
+impl From<Counter> for Metric {
+    fn from(f: Counter) -> Metric {
+        Metric::Counter(Arc::new(f))
+    }
+}
+
+impl From<Gauge> for Metric {
+    fn from(f: Gauge) -> Metric {
+        Metric::Gauge(Arc::new(f))
+    }
+}
+
+impl From<Histogram> for Metric {
+    fn from(f: Histogram) -> Metric {
+        Metric::Histogram(Arc::new(f))
+    }
+}
+
 #[cfg(feature = "ser")]
 impl Serialize for Metric {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -20,6 +20,33 @@ pub enum Metric {
     Counter(Arc<Counter>),
 }
 
+impl Metric {
+    /// Create default meter
+    pub fn meter() -> Meter {
+        Meter::new()
+    }
+
+    /// Create default timer
+    pub fn timer() -> Timer {
+        Timer::new()
+    }
+
+    /// Create gauge with given function
+    pub fn gauge(f: GaugeFn) -> Gauge {
+        Gauge::new(f)
+    }
+
+    /// Create default histogram
+    pub fn histogram() -> Histogram {
+        Histogram::new()
+    }
+
+    /// Create default counter
+    pub fn counter() -> Counter {
+        Counter::new()
+    }
+}
+
 #[cfg(feature = "ser")]
 impl Serialize for Metric {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/metriki-core/src/metrics/mset.rs
+++ b/metriki-core/src/metrics/mset.rs
@@ -1,0 +1,7 @@
+use std::fmt::Debug;
+
+use super::Metric;
+
+pub trait MetricsSet: Debug {
+    fn get_all(&self) -> Vec<Metric>;
+}

--- a/metriki-core/src/mset.rs
+++ b/metriki-core/src/mset.rs
@@ -3,6 +3,14 @@ use std::fmt::Debug;
 
 use crate::metrics::Metric;
 
+/// The `MetricsSet` trait defines a structure that provides
+/// dynamic metrics to the registry.
+///
+/// By default, all metrics created from `MetricsRegistry` are
+/// static ones. Once it was created the registry holds and tracks
+/// it automatically. in contrast, `MetricsSet` is pulled by registry
+/// to provide metrics everytime. This is useful to implement features
+/// like "Top 10 APIs".
 pub trait MetricsSet: Send + Sync + Debug {
     fn get_all(&self) -> HashMap<String, Metric>;
 }

--- a/metriki-core/src/mset.rs
+++ b/metriki-core/src/mset.rs
@@ -6,3 +6,40 @@ use crate::metrics::Metric;
 pub trait MetricsSet: Send + Sync + Debug {
     fn get_all(&self) -> HashMap<String, Metric>;
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::MetricsSet;
+    use crate::metrics::Metric;
+    use crate::registry::MetricsRegistry;
+
+    #[derive(Debug)]
+    struct DummyMetricsSet;
+
+    impl MetricsSet for DummyMetricsSet {
+        fn get_all(&self) -> HashMap<String, Metric> {
+            let counter = Metric::counter();
+            counter.inc(10);
+
+            let mut map: HashMap<String, Metric> = HashMap::new();
+            map.insert("test.set.counter".to_owned(), counter.into());
+
+            map
+        }
+    }
+
+    #[test]
+    fn test_metrics_set() {
+        let registry = MetricsRegistry::new();
+        registry.register_metrics_set("dummy", Box::new(DummyMetricsSet));
+        registry.counter("test.default.counter").inc(1);
+
+        let snapshots = registry.snapshots();
+
+        assert_eq!(2, snapshots.len());
+        assert!(snapshots.get("test.set.counter").is_some());
+        assert!(snapshots.get("test.default.counter").is_some());
+    }
+}

--- a/metriki-core/src/mset.rs
+++ b/metriki-core/src/mset.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use super::Metric;
+use crate::metrics::Metric;
 
 pub trait MetricsSet: Debug {
     fn get_all(&self) -> Vec<Metric>;

--- a/metriki-core/src/mset.rs
+++ b/metriki-core/src/mset.rs
@@ -3,6 +3,6 @@ use std::fmt::Debug;
 
 use crate::metrics::Metric;
 
-pub trait MetricsSet: Debug {
+pub trait MetricsSet: Send + Sync + Debug {
     fn get_all(&self) -> HashMap<String, Metric>;
 }

--- a/metriki-core/src/mset.rs
+++ b/metriki-core/src/mset.rs
@@ -18,6 +18,7 @@ pub trait MetricsSet: Send + Sync + Debug {
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use super::MetricsSet;
     use crate::metrics::Metric;
@@ -41,7 +42,7 @@ mod test {
     #[test]
     fn test_metrics_set() {
         let registry = MetricsRegistry::new();
-        registry.register_metrics_set("dummy", Box::new(DummyMetricsSet));
+        registry.register_metrics_set("dummy", Arc::new(DummyMetricsSet));
         registry.counter("test.default.counter").inc(1);
 
         let snapshots = registry.snapshots();

--- a/metriki-core/src/mset.rs
+++ b/metriki-core/src/mset.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use crate::metrics::Metric;
 
 pub trait MetricsSet: Debug {
-    fn get_all(&self) -> Vec<Metric>;
+    fn get_all(&self) -> HashMap<String, Metric>;
 }

--- a/metriki-core/src/registry.rs
+++ b/metriki-core/src/registry.rs
@@ -30,7 +30,7 @@ impl Debug for MetricsRegistry {
 #[derive(Default, Debug)]
 struct Inner {
     metrics: HashMap<String, Metric>,
-    mset: HashMap<String, Box<dyn MetricsSet + 'static>>,
+    mset: HashMap<String, Arc<dyn MetricsSet + 'static>>,
 }
 
 impl MetricsRegistry {
@@ -207,7 +207,7 @@ impl MetricsRegistry {
     ///
     /// The name has nothing to do with metrics it added to `snapshots()` results.
     /// It's just for identify the metrics set for dedup and removal.
-    pub fn register_metrics_set(&self, name: &str, mset: Box<dyn MetricsSet + 'static>) {
+    pub fn register_metrics_set(&self, name: &str, mset: Arc<dyn MetricsSet + 'static>) {
         let mut inner = self.inner.write().unwrap();
         inner.mset.insert(name.to_owned(), mset);
     }

--- a/metriki-core/src/registry.rs
+++ b/metriki-core/src/registry.rs
@@ -193,11 +193,20 @@ impl MetricsRegistry {
         self.filter = filter;
     }
 
+    /// Register a MetricsSet implementation.
+    ///
+    /// A MetricsSet returns a set of metrics when `snapshots()` is called on
+    /// the registry. This provides dynamic metrics that can be added into registry
+    /// based custom rules.
+    ///
+    /// The name has nothing to do with metrics it added to `snapshots()` results.
+    /// It's just for identify the metrics set for dedup and removal.
     pub fn register_metrics_set(&self, name: &str, mset: Box<dyn MetricsSet + 'static>) {
         let mut inner = self.inner.write().unwrap();
         inner.mset.insert(name.to_owned(), mset);
     }
 
+    /// Unregister a MetricsSet implementation by its name.
     pub fn unregister_metrics_set(&self, name: &str) {
         let mut inner = self.inner.write().unwrap();
         inner.mset.remove(name);


### PR DESCRIPTION
This new concept adds dynamic metrics to the `MetricsRegistry`. You can register your own `MetricsSet` that provide its own metrics when reporters pulling the registry.

Tasks

- [x] The API
- [x] `MetricsRegistry` integration
- [x] `Metric` API enhancements: provide public factory methods without auto registration
- [x] `Metric` `as_xxx` APIs that returns inner types
- [x] Tests
- [x] Docs + ReadMe
- [x] Examples
 