### PR TITLE
Export timer context

### DIFF
--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -135,4 +135,4 @@ pub use counter::Counter;
 pub use gauge::{Gauge, GaugeFn};
 pub use histogram::{Histogram, HistogramSnapshot};
 pub use meter::Meter;
-pub use timer::Timer;
+pub use timer::{Timer, TimerContext};


### PR DESCRIPTION
TimerContext was a private type. It made it's impossible for an application to cache it.