### PR TITLE
Tower instrument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = ["metriki-core",
            "metriki-prometheus-exporter",
            "metriki-riemann-reporter",
            "metriki-statsd-reporter",
+           "metriki-tower",
            "metriki-warp"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ InfluxDbReporterBuilder::default()
   - [x] statsd [(doc)](https://docs.rs/metriki-statsd-reporter/) [(crate)](https://crates.io/crates/metriki-statsd-reporter)
 - Instruments
   - [x] warp [(doc)](https://docs.rs/metriki-warp/) [(crate)](https://crates.io/crates/metriki-warp)
-  - [ ] ?reqwest
+  - [x] tower [(doc)](https://docs.rs/metriki-tower/) [(crate)](https://crates.io/crates/metriki-tower)
+  - [ ] reqwest
 
 ## Concepts
 

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -135,4 +135,4 @@ pub use counter::Counter;
 pub use gauge::{Gauge, GaugeFn};
 pub use histogram::{Histogram, HistogramSnapshot};
 pub use meter::Meter;
-pub use timer::{Timer, TimerContext};
+pub use timer::{Timer, TimerContext, TimerContext2};

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -135,4 +135,4 @@ pub use counter::Counter;
 pub use gauge::{Gauge, GaugeFn};
 pub use histogram::{Histogram, HistogramSnapshot};
 pub use meter::Meter;
-pub use timer::{Timer, TimerContext, TimerContext2};
+pub use timer::{Timer, TimerContext, TimerContextArc};

--- a/metriki-core/src/metrics/timer.rs
+++ b/metriki-core/src/metrics/timer.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Instant;
 
 #[cfg(feature = "ser")]
@@ -20,6 +21,29 @@ pub struct Timer {
 pub struct TimerContext<'a> {
     start_at: Instant,
     timer: &'a Timer,
+}
+
+#[derive(Debug)]
+pub struct TimerContext2 {
+    start_at: Instant,
+    timer: Arc<Timer>,
+}
+
+impl TimerContext2 {
+    pub fn start(timer: Arc<Timer>) -> TimerContext2 {
+        timer.rate.mark();
+        TimerContext2 {
+            start_at: Instant::now(),
+            timer: timer.clone(),
+        }
+    }
+
+    pub fn stop(self) {
+        let elapsed = Instant::now() - self.start_at;
+        let elapsed_ms = elapsed.as_millis();
+
+        self.timer.latency.update(elapsed_ms as u64);
+    }
 }
 
 impl Timer {

--- a/metriki-core/src/metrics/timer.rs
+++ b/metriki-core/src/metrics/timer.rs
@@ -45,10 +45,7 @@ impl TimerContextArc {
     /// The returned `TimerContext` can be stopped or dropped to record its timing.
     pub fn start_at(timer: Arc<Timer>, start_at: Instant) -> TimerContextArc {
         timer.rate.mark();
-        TimerContextArc {
-            start_at,
-            timer: timer.clone(),
-        }
+        TimerContextArc { start_at, timer }
     }
 
     /// Stop the timer context.

--- a/metriki-tower/Cargo.toml
+++ b/metriki-tower/Cargo.toml
@@ -15,3 +15,4 @@ tower-service = "0.3"
 tower-layer = "0.3"
 futures = "0.3"
 metriki-core = { path = "../metriki-core", version = "^1.0"}
+derive_builder = "0.9.0"

--- a/metriki-tower/Cargo.toml
+++ b/metriki-tower/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "metriki-tower"
+version = "0.1.0"
+authors = ["Ning Sun <sunng@protonmail.com>"]
+edition = "2018"
+description = "Metriki integration with tower"
+license = "MIT/Apache-2.0"
+keywords = ["observability", "metrics", "monitoring", "tower"]
+homepage = "https://github.com/sunng87/metriki"
+repository = "https://github.com/sunng87/metriki"
+documentation = "https://docs.rs/metriki-tower/"
+
+[dependencies]
+tower-service = "0.3"
+tower-layer = "0.3"
+futures = "0.3"
+metriki-core = { path = "../metriki-core", version = "^1.0"}

--- a/metriki-tower/src/lib.rs
+++ b/metriki-tower/src/lib.rs
@@ -1,0 +1,49 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::{Future, FutureExt, TryFutureExt};
+use metriki_core::metrics::TimerContext2;
+use metriki_core::MetricsRegistry;
+use tower_service::Service;
+
+pub struct MetrikiMiddleware<S> {
+    registry: Arc<MetricsRegistry>,
+    inner: S,
+}
+
+impl<S, R> Service<R> for MetrikiMiddleware<S>
+where
+    S: Service<R>,
+    S::Future: 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        let registry = self.registry.clone();
+        let timer = registry.timer("requests");
+        let timer_ctx = TimerContext2::start(timer);
+
+        let f = self
+            .inner
+            .call(req)
+            .map(|resp| {
+                timer_ctx.stop();
+                resp
+            })
+            .map_err(move |e| {
+                registry.meter("requests.error").mark();
+                e
+            });
+
+        Box::pin(f)
+    }
+}
+
+// TODO: layer

--- a/metriki-tower/src/lib.rs
+++ b/metriki-tower/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::{Future, FutureExt, TryFutureExt};
-use metriki_core::metrics::TimerContext2;
+use metriki_core::metrics::TimerContextArc;
 use metriki_core::MetricsRegistry;
 use tower_service::Service;
 
@@ -28,7 +28,7 @@ where
     fn call(&mut self, req: R) -> Self::Future {
         let registry = self.registry.clone();
         let timer = registry.timer("requests");
-        let timer_ctx = TimerContext2::start(timer);
+        let timer_ctx = TimerContextArc::start(timer);
 
         let f = self
             .inner

--- a/metriki-tower/src/lib.rs
+++ b/metriki-tower/src/lib.rs
@@ -2,24 +2,38 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use derive_builder::Builder;
 use futures::{Future, FutureExt, TryFutureExt};
 use metriki_core::metrics::TimerContextArc;
 use metriki_core::MetricsRegistry;
+use tower_layer::Layer;
 use tower_service::Service;
 
-pub struct MetrikiMiddleware<S> {
+pub struct MetricsService<S> {
     registry: Arc<MetricsRegistry>,
+    base_metric_name: Option<String>,
     inner: S,
 }
 
-impl<S, R> Service<R> for MetrikiMiddleware<S>
+impl<S> MetricsService<S> {
+    fn name(&self) -> String {
+        self.base_metric_name
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| "requests".to_owned())
+    }
+}
+
+type ResultFuture<R, E> = Pin<Box<dyn Future<Output = Result<R, E>>>>;
+
+impl<S, R> Service<R> for MetricsService<S>
 where
     S: Service<R>,
     S::Future: 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + 'static>>;
+    type Future = ResultFuture<Self::Response, Self::Error>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
@@ -27,7 +41,8 @@ where
 
     fn call(&mut self, req: R) -> Self::Future {
         let registry = self.registry.clone();
-        let timer = registry.timer("requests");
+        let name = self.name();
+        let timer = registry.timer(&name);
         let timer_ctx = TimerContextArc::start(timer);
 
         let f = self
@@ -38,7 +53,7 @@ where
                 resp
             })
             .map_err(move |e| {
-                registry.meter("requests.error").mark();
+                registry.meter(&format!("{}.error", name)).mark();
                 e
             });
 
@@ -46,4 +61,22 @@ where
     }
 }
 
-// TODO: layer
+/// The tower layer to generate tower services for Metriki
+#[derive(Builder, Debug)]
+pub struct MetricsLayer {
+    registry: Arc<MetricsRegistry>,
+    #[builder(default, setter(into))]
+    base_metric_name: Option<String>,
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        MetricsService {
+            registry: self.registry.clone(),
+            inner: service,
+            base_metric_name: self.base_metric_name.clone(),
+        }
+    }
+}


### PR DESCRIPTION
Fixes #33 

This patch adds a tower layer/service for using metriki with tower application.

The layer/service tracks your service execution, with:

* A timer for qps and process latency
* A meter to track error rate
