### PR TITLE
Jemalloc instrument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 [workspace]
 members = ["metriki-core",
            "metriki-influxdb-reporter",
+           "metriki-jemalloc",
            "metriki-log-reporter",
            "metriki-macros",
            "metriki-prometheus-exporter",

--- a/metriki-jemalloc/Cargo.toml
+++ b/metriki-jemalloc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "metriki-jemalloc"
+version = "0.1.0"
+authors = ["Ning Sun <sunng@protonmail.com>"]
+edition = "2018"
+description = "Metriki integration for jemalloc"
+license = "MIT/Apache-2.0"
+keywords = ["observability", "metrics", "monitoring", "memory"]
+homepage = "https://github.com/sunng87/metriki"
+repository = "https://github.com/sunng87/metriki"
+documentation = "https://docs.rs/metriki-jemalloc/"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tikv-jemalloc-ctl = "0.4"
+metriki-core = { path = "../metriki-core", version = "^1.0"}

--- a/metriki-jemalloc/Cargo.toml
+++ b/metriki-jemalloc/Cargo.toml
@@ -15,3 +15,8 @@ documentation = "https://docs.rs/metriki-jemalloc/"
 [dependencies]
 tikv-jemalloc-ctl = "0.4"
 metriki-core = { path = "../metriki-core", version = "^1.0"}
+
+[dev-dependencies]
+tikv-jemallocator = "0.4"
+metriki-log-reporter = { path = "../metriki-log-reporter", version = "0.1" }
+env_logger = "0.9"

--- a/metriki-jemalloc/examples/jemalloc.rs
+++ b/metriki-jemalloc/examples/jemalloc.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use metriki_core::global::global_registry;
+use metriki_jemalloc::JemallocMetricsSet;
+use metriki_log_reporter::LogReporterBuilder;
+use tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+fn main() {
+    env_logger::init();
+    global_registry().register_metrics_set(
+        "memory",
+        Arc::new(JemallocMetricsSet::new("example.memory")),
+    );
+
+    LogReporterBuilder::default()
+        .registry(global_registry())
+        .interval_secs(5)
+        .build()
+        .unwrap()
+        .start();
+
+    let mut vecs: Vec<Vec<u8>> = Vec::new();
+    loop {
+        vecs.push(Vec::with_capacity(4 * 1024));
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/metriki-jemalloc/src/lib.rs
+++ b/metriki-jemalloc/src/lib.rs
@@ -21,30 +21,23 @@ impl MetricsSet for JemallocMetricsSet {
 
         epoch::advance().unwrap();
 
-        let active_gauge = Metric::gauge(Box::new(|| stats::active::read().unwrap() as f64)).into();
-        result.insert(format!("{}.jemalloc.active", self.prefix), active_gauge);
+        let active = Metric::gauge(Box::new(|| stats::active::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.active", self.prefix), active);
 
-        let allocated_gauge =
-            Metric::gauge(Box::new(|| stats::allocated::read().unwrap() as f64)).into();
-        result.insert(
-            format!("{}.jemalloc.allocated", self.prefix),
-            allocated_gauge,
-        );
+        let allocated = Metric::gauge(Box::new(|| stats::allocated::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.allocated", self.prefix), allocated);
 
-        let metadata_gauge =
-            Metric::gauge(Box::new(|| stats::metadata::read().unwrap() as f64)).into();
-        result.insert(format!("{}.jemalloc.metadata", self.prefix), metadata_gauge);
+        let metadata = Metric::gauge(Box::new(|| stats::metadata::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.metadata", self.prefix), metadata);
 
-        let mapped_gauge = Metric::gauge(Box::new(|| stats::mapped::read().unwrap() as f64)).into();
-        result.insert(format!("{}.jemalloc.mapped", self.prefix), mapped_gauge);
+        let mapped = Metric::gauge(Box::new(|| stats::mapped::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.mapped", self.prefix), mapped);
 
-        let resident_gauge =
-            Metric::gauge(Box::new(|| stats::resident::read().unwrap() as f64)).into();
-        result.insert(format!("{}.jemalloc.resident", self.prefix), resident_gauge);
+        let resident = Metric::gauge(Box::new(|| stats::resident::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.resident", self.prefix), resident);
 
-        let retained_gauge =
-            Metric::gauge(Box::new(|| stats::retained::read().unwrap() as f64)).into();
-        result.insert(format!("{}.jemalloc.retained", self.prefix), retained_gauge);
+        let retained = Metric::gauge(Box::new(|| stats::retained::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.retained", self.prefix), retained);
 
         result
     }

--- a/metriki-jemalloc/src/lib.rs
+++ b/metriki-jemalloc/src/lib.rs
@@ -9,6 +9,12 @@ pub struct JemallocMetricsSet {
     prefix: &'static str,
 }
 
+impl JemallocMetricsSet {
+    pub fn new(prefix: &'static str) -> JemallocMetricsSet {
+        JemallocMetricsSet { prefix }
+    }
+}
+
 impl MetricsSet for JemallocMetricsSet {
     fn get_all(&self) -> HashMap<String, Metric> {
         let mut result = HashMap::new();

--- a/metriki-jemalloc/src/lib.rs
+++ b/metriki-jemalloc/src/lib.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use metriki_core::metrics::Metric;
+use metriki_core::MetricsSet;
+use tikv_jemalloc_ctl::{epoch, stats};
+
+#[derive(Debug)]
+pub struct JemallocMetricsSet {
+    prefix: &'static str,
+}
+
+impl MetricsSet for JemallocMetricsSet {
+    fn get_all(&self) -> HashMap<String, Metric> {
+        let mut result = HashMap::new();
+
+        epoch::advance().unwrap();
+
+        let active_gauge = Metric::gauge(Box::new(|| stats::active::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.active", self.prefix), active_gauge);
+
+        let allocated_gauge =
+            Metric::gauge(Box::new(|| stats::allocated::read().unwrap() as f64)).into();
+        result.insert(
+            format!("{}.jemalloc.allocated", self.prefix),
+            allocated_gauge,
+        );
+
+        let metadata_gauge =
+            Metric::gauge(Box::new(|| stats::metadata::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.metadata", self.prefix), metadata_gauge);
+
+        let mapped_gauge = Metric::gauge(Box::new(|| stats::mapped::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.mapped", self.prefix), mapped_gauge);
+
+        let resident_gauge =
+            Metric::gauge(Box::new(|| stats::resident::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.resident", self.prefix), resident_gauge);
+
+        let retained_gauge =
+            Metric::gauge(Box::new(|| stats::retained::read().unwrap() as f64)).into();
+        result.insert(format!("{}.jemalloc.retained", self.prefix), retained_gauge);
+
+        result
+    }
+}


### PR DESCRIPTION
This patch includes a `MetricsSet` impl as Jemalloc instrument. It collects memory metrics from `tikv-jemalloc-ctl`.