### PR TITLE
Improved Gauge API

### DIFF
--- a/metriki-core/src/metrics/gauge.rs
+++ b/metriki-core/src/metrics/gauge.rs
@@ -6,11 +6,11 @@ use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
 /// Trait for gauge impls
-pub trait GaugeProvider: Send + Sync {
+pub trait GaugeFn: Send + Sync {
     fn value(&self) -> f64;
 }
 
-impl GaugeProvider for dyn Fn() -> f64 + Send + Sync {
+impl<F: Fn() -> f64 + Send + Sync> GaugeFn for F {
     fn value(&self) -> f64 {
         self()
     }
@@ -18,11 +18,11 @@ impl GaugeProvider for dyn Fn() -> f64 + Send + Sync {
 
 /// Gauges are used to measure the instantaneous value of something.
 pub struct Gauge {
-    func: Box<dyn GaugeProvider>,
+    func: Box<dyn GaugeFn>,
 }
 
 impl Gauge {
-    pub(crate) fn new(f: Box<dyn GaugeProvider>) -> Gauge {
+    pub(crate) fn new(f: Box<dyn GaugeFn>) -> Gauge {
         Gauge { func: f }
     }
 

--- a/metriki-core/src/metrics/gauge.rs
+++ b/metriki-core/src/metrics/gauge.rs
@@ -5,20 +5,29 @@ use serde::ser::SerializeMap;
 #[cfg(feature = "ser")]
 use serde::{Serialize, Serializer};
 
-pub type GaugeFn = Box<dyn Fn() -> f64 + Send + Sync>;
+/// Trait for gauge impls
+pub trait GaugeProvider: Send + Sync {
+    fn value(&self) -> f64;
+}
+
+impl GaugeProvider for dyn Fn() -> f64 + Send + Sync {
+    fn value(&self) -> f64 {
+        self()
+    }
+}
 
 /// Gauges are used to measure the instantaneous value of something.
 pub struct Gauge {
-    func: GaugeFn,
+    func: Box<dyn GaugeProvider>,
 }
 
 impl Gauge {
-    pub(crate) fn new(f: GaugeFn) -> Gauge {
+    pub(crate) fn new(f: Box<dyn GaugeProvider>) -> Gauge {
         Gauge { func: f }
     }
 
     pub fn value(&self) -> f64 {
-        (*self.func)()
+        self.func.value()
     }
 }
 

--- a/metriki-core/src/metrics/mod.rs
+++ b/metriki-core/src/metrics/mod.rs
@@ -30,7 +30,7 @@ impl Metric {
     }
 
     /// Create gauge with given function
-    pub fn gauge(f: GaugeFn) -> Arc<Gauge> {
+    pub fn gauge(f: Box<dyn GaugeFn>) -> Arc<Gauge> {
         Gauge::new(f).into()
     }
 

--- a/metriki-core/src/registry.rs
+++ b/metriki-core/src/registry.rs
@@ -166,7 +166,7 @@ impl MetricsRegistry {
     /// Register a `Gauge` with given function.
     ///
     /// The guage will return a value when any reporter wants to fetch data from it.
-    pub fn gauge(&self, name: &str, func: GaugeFn) {
+    pub fn gauge(&self, name: &str, func: Box<dyn GaugeFn>) {
         let mut inner = self.inner.write().unwrap();
         inner
             .metrics


### PR DESCRIPTION
The new Gauge API made `GaugeFn` a trait instead of Boxed Fn. This improvement is the prerequisite for #41 