### PR TITLE
Metriki as a tracing subscriber layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = ["metriki-core",
            "metriki-riemann-reporter",
            "metriki-statsd-reporter",
            "metriki-tower",
+           "metriki-tracing",
            "metriki-warp"]

--- a/README.md
+++ b/README.md
@@ -40,9 +40,18 @@ InfluxDbReporterBuilder::default()
   - [x] prometheus [(doc)](https://docs.rs/metriki-prometheus-exporter/) [(crate)](https://crates.io/crates/metriki-promethes-exporter)
   - [x] statsd [(doc)](https://docs.rs/metriki-statsd-reporter/) [(crate)](https://crates.io/crates/metriki-statsd-reporter)
 - Instruments
-  - [x] jemalloc [(doc)](https://docs.rs/metriki-jemalloc/) [(crate)](https://crates.io/crates/metriki-jemalloc)
-  - [x] tower + hyper [(doc)](https://docs.rs/metriki-tower/) [(crate)](https://crates.io/crates/metriki-tower)
-  - [x] warp [(doc)](https://docs.rs/metriki-warp/) [(crate)](https://crates.io/crates/metriki-warp).
+  - [x] jemalloc: tracking jemalloc stats
+        [(doc)](https://docs.rs/metriki-jemalloc/)
+        [(crate)](https://crates.io/crates/metriki-jemalloc).
+  - [x] tracing: tracing subscriber layer
+        [(doc)](https://docs.rs/metriki-tracing/)
+        [(crate)](https://crates.io/crates/metriki-tracing).
+  - [x] tower + hyper: tower layer for metriki integration
+        [(doc)](https://docs.rs/metriki-tower/)
+        [(crate)](https://crates.io/crates/metriki-tower).
+  - [x] warp: warp middleware to inject metriki `MetricsRegistry`
+        [(doc)](https://docs.rs/metriki-warp/)
+        [(crate)](https://crates.io/crates/metriki-warp).
 
 
 ## Concepts

--- a/metriki-core/src/metrics/timer.rs
+++ b/metriki-core/src/metrics/timer.rs
@@ -49,7 +49,7 @@ impl TimerContextArc {
     }
 
     /// Stop the timer context.
-    pub fn stop(self) {
+    pub fn stop(&self) {
         let elapsed = Instant::now() - self.start_at;
         let elapsed_ms = elapsed.as_millis();
 

--- a/metriki-tower/src/lib.rs
+++ b/metriki-tower/src/lib.rs
@@ -54,7 +54,7 @@ where
         let f = self
             .inner
             .call(req)
-            .map(|resp| {
+            .map(move |resp| {
                 timer_ctx.stop();
                 resp
             })

--- a/metriki-tracing/Cargo.toml
+++ b/metriki-tracing/Cargo.toml
@@ -15,5 +15,6 @@ readme = "../README.md"
 
 [dependencies]
 tracing = "0.1"
+tracing-subscriber = { version = "0.2", default-features = false, features = ["registry"] }
 metriki-core = { path = "../metriki-core", version = "^1.0"}
 derive_builder = "0.9.0"

--- a/metriki-tracing/Cargo.toml
+++ b/metriki-tracing/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "metriki-tracing"
+version = "0.1.0"
+authors = ["Ning Sun <sunng@protonmail.com>"]
+edition = "2018"
+description = "Metriki as a subscriber of tracing"
+license = "MIT/Apache-2.0"
+keywords = ["observability", "metrics", "monitoring", "tracing"]
+homepage = "https://github.com/sunng87/metriki"
+repository = "https://github.com/sunng87/metriki"
+documentation = "https://docs.rs/metriki-tracing/"
+readme = "../README.md"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1"
+metriki-core = { path = "../metriki-core", version = "^1.0"}
+derive_builder = "0.9.0"

--- a/metriki-tracing/Cargo.toml
+++ b/metriki-tracing/Cargo.toml
@@ -18,3 +18,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["registry"] }
 metriki-core = { path = "../metriki-core", version = "^1.0"}
 derive_builder = "0.9.0"
+
+[dev-dependencies]
+metriki-log-reporter = { path = "../metriki-log-reporter", version = "0.1" }
+env_logger = "0.8"

--- a/metriki-tracing/examples/simple.rs
+++ b/metriki-tracing/examples/simple.rs
@@ -1,19 +1,30 @@
-use std::error::Error;
+use std::time::Duration;
 
 use metriki_core::global::global_registry;
+use metriki_log_reporter::LogReporterBuilder;
 use metriki_tracing::MetrikiLayer;
 use tracing::Level;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::Registry;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() {
+    env_logger::init();
+    LogReporterBuilder::default()
+        .registry(global_registry())
+        .interval_secs(2)
+        .build()
+        .unwrap()
+        .start();
+
     let layer = MetrikiLayer::new(global_registry());
     let subscriber = Registry::default().with(layer);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    let span = tracing::span!(Level::INFO, "demo");
+    loop {
+        let span = tracing::span!(Level::INFO, "demo");
+        let _enter = span.enter();
 
-    drop(span);
-
-    Ok(())
+        tracing::info!("demo_sleep");
+        std::thread::sleep(Duration::from_millis(1000));
+    }
 }

--- a/metriki-tracing/examples/simple.rs
+++ b/metriki-tracing/examples/simple.rs
@@ -1,0 +1,7 @@
+use metriki_core::MetricsRegistry;
+use metriki_tracing::MetrikiSubscriber;
+use tracing;
+
+fn main() -> Result<(), Box<Error>> {
+    MetrikiSubscriber::new().init();
+}

--- a/metriki-tracing/examples/simple.rs
+++ b/metriki-tracing/examples/simple.rs
@@ -1,7 +1,19 @@
-use metriki_core::MetricsRegistry;
-use metriki_tracing::MetrikiSubscriber;
-use tracing;
+use std::error::Error;
 
-fn main() -> Result<(), Box<Error>> {
-    MetrikiSubscriber::new().init();
+use metriki_core::global::global_registry;
+use metriki_tracing::MetrikiLayer;
+use tracing::Level;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::Registry;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let layer = MetrikiLayer::new(global_registry());
+    let subscriber = Registry::default().with(layer);
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let span = tracing::span!(Level::INFO, "demo");
+
+    drop(span);
+
+    Ok(())
 }

--- a/metriki-tracing/src/lib.rs
+++ b/metriki-tracing/src/lib.rs
@@ -46,7 +46,7 @@ where
 }
 
 impl MetrikiLayer {
-    // Create `MetrikiSubscriber` with default settings
+    // Create `MetrikiLayer` from a Metriki MetricsRegistry
     pub fn new(registry: Arc<MetricsRegistry>) -> MetrikiLayer {
         MetrikiLayer {
             registry: registry.clone(),

--- a/metriki-tracing/src/lib.rs
+++ b/metriki-tracing/src/lib.rs
@@ -48,8 +48,6 @@ where
 impl MetrikiLayer {
     // Create `MetrikiLayer` from a Metriki MetricsRegistry
     pub fn new(registry: Arc<MetricsRegistry>) -> MetrikiLayer {
-        MetrikiLayer {
-            registry: registry.clone(),
-        }
+        MetrikiLayer { registry }
     }
 }

--- a/metriki-tracing/src/lib.rs
+++ b/metriki-tracing/src/lib.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tracing::Subscriber;
+
+use metriki_core::metrics::TimerContextArc;
+use metriki_core::MetricsRegistry;
+
+pub struct MetrikiSubscriber {
+    registry: Arc<MetricsRegistry>,
+    enabled: bool,
+    active_timers: Arc<Mutex<HashMap<tracing::Id, TimerContextArc>>>,
+    id_gen: AtomicU64,
+}
+
+impl Subscriber for MetrikiSubscriber {
+    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+        // check metadata to
+        self.enabled
+    }
+
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::Id {
+        let next_id = self.id_gen.fetch_add(1, Ordering::SeqCst);
+        tracing::Id::from_u64(next_id)
+    }
+
+    fn record(&self, _: &tracing::Id, _: &tracing::span::Record<'_>) {
+        todo!()
+    }
+    fn record_follows_from(&self, _: &tracing::Id, _: &tracing::Id) {
+        todo!()
+    }
+    fn event(&self, _: &tracing::Event<'_>) {
+        todo!()
+    }
+    fn enter(&self, _: &tracing::Id) {
+        todo!()
+    }
+    fn exit(&self, _: &tracing::Id) {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/metriki-tracing/src/lib.rs
+++ b/metriki-tracing/src/lib.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tracing::Subscriber;
 use tracing::{Event, Id};
@@ -12,16 +10,13 @@ use tracing_subscriber::{
 use metriki_core::metrics::TimerContextArc;
 use metriki_core::MetricsRegistry;
 
-// A tracing subscriber that tracks span and events with Metriki timers
+// A tracing layer that tracks span and events with Metriki timers
 // and meters.
-pub struct MetrikiSubscriber {
+pub struct MetrikiLayer {
     registry: Arc<MetricsRegistry>,
-    enabled: bool,
-    active_timers: Arc<Mutex<HashMap<tracing::Id, TimerContextArc>>>,
-    id_gen: AtomicU64,
 }
 
-impl<S> Layer<S> for MetrikiSubscriber
+impl<S> Layer<S> for MetrikiLayer
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
@@ -30,79 +25,31 @@ where
         self.registry.meter(event.metadata().name()).mark();
     }
 
-    fn on_enter(&self, span_id: &Id, ctx: Context<'_, S>) {
-        let span = ctx.current_span();
-        if let Some(metadata) = span.metadata() {
+    fn on_enter(&self, _id: &Id, ctx: Context<'_, S>) {
+        if let Some(span_ref) = ctx.lookup_current() {
+            let metadata = span_ref.metadata();
             let name = metadata.name();
             let timer = self.registry.timer(name);
             let timer_ctx = TimerContextArc::start(timer);
 
-            // FIXME: use stored data API to cache this timer_ctx
-            let mut timer_purgator = self.active_timers.lock().unwrap();
-            timer_purgator.insert(span_id.clone(), timer_ctx);
+            span_ref.extensions_mut().insert(timer_ctx);
         }
     }
 
-    fn on_exit(&self, span_id: &Id, _ctx: Context<'_, S>) {
-        let mut timer_purgator = self.active_timers.lock().unwrap();
-        if let Some(timer_ctx) = timer_purgator.remove(span_id) {
-            timer_ctx.stop();
-        }
-    }
-}
-
-impl Subscriber for MetrikiSubscriber {
-    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
-        // check metadata to
-        self.enabled
-    }
-
-    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::Id {
-        let next_id = self.id_gen.fetch_add(1, Ordering::SeqCst);
-        tracing::Id::from_u64(next_id)
-    }
-
-    fn record(&self, _: &tracing::Id, _: &tracing::span::Record<'_>) {
-        // do nothing
-    }
-
-    fn record_follows_from(&self, _: &tracing::Id, _: &tracing::Id) {
-        // do nothing
-    }
-
-    fn event(&self, event: &tracing::Event<'_>) {
-        // register event as meter
-        self.registry.meter(event.metadata().name()).mark();
-    }
-
-    fn enter(&self, span_id: &tracing::Id) {
-        let span = self.current_span();
-        if let Some(metadata) = span.metadata() {
-            let name = metadata.name();
-            let timer = self.registry.timer(name);
-            let timer_ctx = TimerContextArc::start(timer);
-
-            let mut timer_purgator = self.active_timers.lock().unwrap();
-            timer_purgator.insert(span_id.clone(), timer_ctx);
-        }
-    }
-
-    fn exit(&self, span_id: &tracing::Id) {
-        let mut timer_purgator = self.active_timers.lock().unwrap();
-        if let Some(timer_ctx) = timer_purgator.remove(span_id) {
-            timer_ctx.stop();
+    fn on_exit(&self, _id: &Id, ctx: Context<'_, S>) {
+        if let Some(span_ref) = ctx.lookup_current() {
+            if let Some(timer_ctx) = span_ref.extensions().get::<TimerContextArc>() {
+                timer_ctx.stop();
+            }
         }
     }
 }
 
-impl MetrikiSubscriber {
+impl MetrikiLayer {
     // Create `MetrikiSubscriber` with default settings
-    pub fn new(registry: Arc<MetricsRegistry>) -> MetrikiSubscriber {
-        MetrikiSubscriber {
+    pub fn new(registry: Arc<MetricsRegistry>) -> MetrikiLayer {
+        MetrikiLayer {
             registry: registry.clone(),
-            enabled: true,
-            active_timers: Arc::new(Mutex::new(HashMap::new())),
-            id_gen: AtomicU64::new(0),
         }
     }
 }

--- a/metriki-tracing/src/lib.rs
+++ b/metriki-tracing/src/lib.rs
@@ -1,3 +1,17 @@
+//! # Metriki as a Tracing Backend
+//!
+//! This library acts as a backend for
+//! [tracing](https://github.com/tokio-rs/tracing). It tracks spans
+//! and events created with tracing API and translates them into
+//! [metriki](https://github.com/sunng87/metriki) concepts.
+//!
+//! * Spans are recorded with metriki timers.
+//! * Events are recorded with metriki meters.
+//!
+//! By using this backend, developers are able to add Metriki and its
+//! exporter/reporter ecosystem into tracing without touching metriki
+//! apis.
+//!
 use std::sync::Arc;
 
 use tracing::Subscriber;
@@ -10,8 +24,21 @@ use tracing_subscriber::{
 use metriki_core::metrics::TimerContextArc;
 use metriki_core::MetricsRegistry;
 
-// A tracing layer that tracks span and events with Metriki timers
-// and meters.
+// A tracing layer to be integrated with tracing_subscriber's
+// Registry.
+//
+// ```no_run
+// // Create MetrikiLayer from metriki registry
+// let layer = MetrikiLayer::new(global_registry());
+//
+// // Create a subscriber with tracing_subscriber's Registry and
+// // configure MetrikiLayer with it
+// let subscriber = Registry::default().with(layer);
+//
+// // Configure the subscriber to tracing
+// tracing::subscriber::set_global_default(subscriber).unwrap();
+// ```
+//
 pub struct MetrikiLayer {
     registry: Arc<MetricsRegistry>,
 }
@@ -22,6 +49,7 @@ where
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         // register event as meter
+        // FIXME: better event metrics name
         self.registry.meter(event.metadata().name()).mark();
     }
 


### PR DESCRIPTION
This patch add a metriki extension to work with tracing as its subscriber backend.

- All tracing spans are tracked by metriki timers
- All tracing events are tracked by metriki meters.