### PR TITLE
feat: use dashmap

### DIFF
--- a/metriki-core/Cargo.toml
+++ b/metriki-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metriki-core"
-version = "1.7.1"
+version = "1.7.2"
 authors = ["Ning Sun <sunng@protonmail.com>"]
 edition = "2018"
 description = "A metrics library ported from dropwizard metrics"
@@ -15,6 +15,7 @@ readme = "../README.md"
 crossbeam-utils = "0.8"
 hdrhistogram = { version = "7", default-features = false, features = [] }
 lazy_static = "1"
+dashmap = "5.0"
 
 # optionals
 ## serialization


### PR DESCRIPTION
metriki core use `Arc<RwLock<Inner>>` locks whole metrics and mset. Performance can be improved by using `dashmap`.