### PR TITLE
downgrade dashmap from 5.0 to 4.0

### DIFF
--- a/metriki-core/Cargo.toml
+++ b/metriki-core/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 crossbeam-utils = "0.8"
 hdrhistogram = { version = "7", default-features = false, features = [] }
 lazy_static = "1"
-dashmap = "5.0"
+dashmap = "4.0"
 
 # optionals
 ## serialization


### PR DESCRIPTION
because of dashmap issue https://github.com/xacrimon/dashmap/issues/167 which `cargo audit` shows, we should downgrade it until fixed.